### PR TITLE
Handle order lookup failures in payment service

### DIFF
--- a/payment-service/src/main/java/com/ecommerce/paymentservice/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/ecommerce/paymentservice/controller/PaymentController.java
@@ -2,6 +2,8 @@ package com.ecommerce.paymentservice.controller;
 
 import com.ecommerce.paymentservice.dto.PaymentRequestDto;
 import com.ecommerce.paymentservice.dto.PaymentResponseDto;
+import com.ecommerce.paymentservice.exception.ErrorResponse;
+import com.ecommerce.paymentservice.exception.OrderNotFoundException;
 import com.ecommerce.paymentservice.model.PaymentStatus;
 import com.ecommerce.paymentservice.service.PaymentService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,8 +16,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.WebRequest;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/payments")
@@ -97,5 +101,17 @@ public class PaymentController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deletePayment(@PathVariable Long id) {
         paymentService.deletePayment(id);
+    }
+
+    @ExceptionHandler(OrderNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleOrderNotFoundException(OrderNotFoundException ex, WebRequest request) {
+        return new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                ex.getMessage(),
+                request.getDescription(false)
+        );
     }
 }

--- a/payment-service/src/main/java/com/ecommerce/paymentservice/exception/GlobalExceptionHandler.java
+++ b/payment-service/src/main/java/com/ecommerce/paymentservice/exception/GlobalExceptionHandler.java
@@ -26,6 +26,18 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
+    @ExceptionHandler(OrderNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleOrderNotFoundException(OrderNotFoundException ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                ex.getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
     @ExceptionHandler(OrderServiceCommunicationException.class)
     public ResponseEntity<ErrorResponse> handleOrderServiceCommunicationException(OrderServiceCommunicationException ex, WebRequest request) {
         ErrorResponse errorResponse = new ErrorResponse(

--- a/payment-service/src/main/java/com/ecommerce/paymentservice/exception/OrderNotFoundException.java
+++ b/payment-service/src/main/java/com/ecommerce/paymentservice/exception/OrderNotFoundException.java
@@ -1,0 +1,11 @@
+package com.ecommerce.paymentservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class OrderNotFoundException extends RuntimeException {
+    public OrderNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/payment-service/src/main/java/com/ecommerce/paymentservice/service/PaymentService.java
+++ b/payment-service/src/main/java/com/ecommerce/paymentservice/service/PaymentService.java
@@ -3,6 +3,7 @@ package com.ecommerce.paymentservice.service;
 import com.ecommerce.paymentservice.dto.OrderDetailsDto;
 import com.ecommerce.paymentservice.dto.PaymentRequestDto;
 import com.ecommerce.paymentservice.dto.PaymentResponseDto;
+import com.ecommerce.paymentservice.exception.OrderNotFoundException;
 import com.ecommerce.paymentservice.exception.OrderServiceCommunicationException;
 import com.ecommerce.paymentservice.exception.PaymentAlreadyExistsException;
 import com.ecommerce.paymentservice.exception.PaymentNotFoundException;
@@ -148,7 +149,7 @@ public class PaymentService {
                                     .flatMap(errorBody -> {
                                         log.error("Order Service returned client error for order ID {}: {}. Status: {}", orderId, errorBody, clientResponse.statusCode());
                                         if (clientResponse.statusCode() == HttpStatus.NOT_FOUND) {
-                                            return Mono.<Throwable>error(new PaymentNotFoundException("Order not found with ID: " + orderId));
+                                            return Mono.<Throwable>error(new OrderNotFoundException("Order not found with ID: " + orderId));
                                         }
                                         return Mono.<Throwable>error(new OrderServiceCommunicationException("Error from Order Service: " + clientResponse.statusCode() + " - " + errorBody));
                                     })

--- a/payment-service/src/test/java/com/ecommerce/paymentservice/controller/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ecommerce/paymentservice/controller/PaymentControllerTest.java
@@ -1,0 +1,49 @@
+package com.ecommerce.paymentservice.controller;
+
+import com.ecommerce.paymentservice.dto.PaymentRequestDto;
+import com.ecommerce.paymentservice.exception.OrderNotFoundException;
+import com.ecommerce.paymentservice.service.PaymentService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PaymentController.class)
+class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PaymentService paymentService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void processPaymentReturns404WhenOrderNotFound() throws Exception {
+        when(paymentService.processPayment(any(PaymentRequestDto.class)))
+                .thenThrow(new OrderNotFoundException("Order not found"));
+
+        PaymentRequestDto request = PaymentRequestDto.builder()
+                .orderId(1L)
+                .paymentMethod("CARD")
+                .amount(BigDecimal.TEN)
+                .build();
+
+        mockMvc.perform(post("/api/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/payment-service/src/test/java/com/ecommerce/paymentservice/service/PaymentServiceTest.java
+++ b/payment-service/src/test/java/com/ecommerce/paymentservice/service/PaymentServiceTest.java
@@ -1,0 +1,59 @@
+package com.ecommerce.paymentservice.service;
+
+import com.ecommerce.paymentservice.dto.PaymentRequestDto;
+import com.ecommerce.paymentservice.exception.OrderNotFoundException;
+import com.ecommerce.paymentservice.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
+    private PaymentService paymentService;
+
+    @BeforeEach
+    void setUp() {
+        paymentService = new PaymentService(paymentRepository, webClientBuilder);
+        ReflectionTestUtils.setField(paymentService, "orderServiceUrl", "http://orderservice");
+    }
+
+    @Test
+    void processPaymentThrowsOrderNotFoundExceptionWhenOrderServiceReturns404() {
+        when(paymentRepository.existsByOrderId(anyLong())).thenReturn(false);
+
+        ExchangeFunction exchangeFunction = request -> Mono.just(
+                ClientResponse.create(HttpStatus.NOT_FOUND).body("Order not found").build()
+        );
+        WebClient webClient = WebClient.builder().exchangeFunction(exchangeFunction).build();
+        when(webClientBuilder.build()).thenReturn(webClient);
+
+        PaymentRequestDto requestDto = PaymentRequestDto.builder()
+                .orderId(1L)
+                .paymentMethod("CARD")
+                .amount(BigDecimal.TEN)
+                .build();
+
+        assertThrows(OrderNotFoundException.class, () -> paymentService.processPayment(requestDto));
+    }
+}


### PR DESCRIPTION
## Summary
- Throw new `OrderNotFoundException` when the order service reports a missing order
- Surface `OrderNotFoundException` as HTTP 404 via controller and global handlers
- Add unit tests for 404 responses from service and controller